### PR TITLE
adding support for partitioned s3 source

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ shouldSortFiles|true|whether to sort files based on timestamp while listing them
 useInstanceProfileCredentials|false|Whether to use EC2 instance profile credentials for connecting to Amazon SQS
 maxFilesPerTrigger|no default value|maximum number of files to process in a microbatch
 maxFileAge|7d|Maximum age of a file that can be found in this directory
+basePath|no default value|Base path in case of partitioned S3 data. Eg. `s3://bucket/basedDir/part1=10/part2=20/file.json` will have basePath as `s3://bucket/basedDir/`
+
+## Using Parrtitioned S3 Bucket
+
+In case your S3 bucket is partitioned, your schema must contain both data columns as well as partition 
+columns. Moreover, partition columns need to have `isPartitioned` set to `true` in their metadata.
+
+Example:
+```
+val metaData = (new MetadataBuilder).putString("isPartitioned", "true").build()
+
+val partitionedSchema = new StructType().add(StructField(
+          "col1", IntegerType, true, metaData))
+```
+
+Also, `basePath` needs to be specified in case of partitioned S3 bucket. Specifying partitioned
+columns without specifying the `basePath` will throw an error.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ val partitionedSchema = new StructType().add(StructField(
           "col1", IntegerType, true, metaData))
 ```
 
-Also, `basePath` needs to be specified in case of partitioned S3 bucket. Specifying partitioned
-columns without specifying the `basePath` will throw an error.
+Also, `basePath` needs to be specified in the options in case of partitioned S3 bucket. 
+Specifying partitioned columns without specifying the `basePath` will throw an error.
 
 ## Example
 

--- a/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSource.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSource.scala
@@ -54,12 +54,10 @@ class SqsSource(sparkSession: SparkSession,
 
   private val shouldSortFiles = sourceOptions.shouldSortFiles
 
-  private val sqsClient = new SqsClient(sourceOptions, hadoopConf)
-
   private val partitionColumnNames = {
     schema.fields.filter(field => field.metadata.contains(IS_PARTITIONED) &&
       Try(field.metadata.getBoolean(IS_PARTITIONED)).toOption.getOrElse(throw new
-          IllegalArgumentException(s"$IS_PARTITIONED for columns ${field.name} must be true or " +
+          IllegalArgumentException(s"$IS_PARTITIONED for column ${field.name} must be true or " +
             s"false"))
     ).map(_.name)
   }
@@ -71,6 +69,8 @@ class SqsSource(sparkSession: SparkSession,
   } else {
     options
   }
+
+  private val sqsClient = new SqsClient(sourceOptions, hadoopConf)
 
   metadataLog.allFiles().foreach { entry =>
     sqsClient.sqsFileCache.add(entry.path, MessageDescription(entry.timestamp, true, ""))

--- a/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
@@ -37,6 +37,8 @@ class SqsSourceOptions(parameters: CaseInsensitiveMap[String]) extends Logging {
     }
   }
 
+  val basePath: Option[String] = parameters.get("basePath")
+
   /**
    * Maximum age of a file that can be found in this directory, before it is ignored. For the
    * first batch all files will be considered valid.

--- a/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.streaming.sqs
 
 import java.util.Locale
 
-import org.apache.spark.sql.streaming.{StreamingQuery, StreamTest}
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest}
 import org.apache.spark.sql.types._
 
 class SqsSourceSuite extends StreamTest  {
@@ -33,9 +33,9 @@ class SqsSourceSuite extends StreamTest  {
     val expectedMsg = s"$BASE_PATH is mandatory if schema contains partitionColumns"
 
     try {
-      val errorMessage = intercept[IllegalArgumentException] {
+      val errorMessage = intercept[StreamingQueryException] {
 
-        val metaData = (new MetadataBuilder).putString(IS_PARTITIONED, "true").build()
+        val metaData = (new MetadataBuilder).putBoolean(IS_PARTITIONED, true).build()
 
         val partitionedSchema = new StructType().add(StructField(
           "col1", IntegerType, true, metaData))
@@ -50,8 +50,8 @@ class SqsSourceSuite extends StreamTest  {
           .load()
 
         query = reader.writeStream
+          .queryName("testQuery")
           .format("memory")
-          .queryName("missingSchema")
           .start()
 
         query.processAllAvailable()
@@ -75,7 +75,7 @@ class SqsSourceSuite extends StreamTest  {
     val expectedMsg = s"$IS_PARTITIONED for column $columName must be true or false"
 
     try {
-      val errorMessage = intercept[IllegalArgumentException] {
+      val errorMessage = intercept[StreamingQueryException] {
 
         val metaData = (new MetadataBuilder).putString(IS_PARTITIONED, "x").build()
 
@@ -93,7 +93,7 @@ class SqsSourceSuite extends StreamTest  {
 
         query = reader.writeStream
           .format("memory")
-          .queryName("missingSchema")
+          .queryName("testQuery")
           .start()
 
         query.processAllAvailable()

--- a/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming.sqs
+
+import java.util.Locale
+
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamTest}
+import org.apache.spark.sql.types._
+
+class SqsSourceSuite extends StreamTest  {
+
+  import org.apache.spark.sql.streaming.sqs.SqsSource._
+
+  test("partitioned data source - base path not specified") {
+
+    var query: StreamingQuery = null
+
+    val expectedMsg = s"$BASE_PATH is mandatory if schema contains partitionColumns"
+
+    try {
+      val errorMessage = intercept[IllegalArgumentException] {
+
+        val metaData = (new MetadataBuilder).putString(IS_PARTITIONED, "true").build()
+
+        val partitionedSchema = new StructType().add(StructField(
+          "col1", IntegerType, true, metaData))
+
+        val reader = spark
+          .readStream
+          .format("s3-sqs")
+          .option("sqsUrl", "https://DUMMY_URL")
+          .option("fileFormat", "json")
+          .option("region", "us-east-1")
+          .schema(partitionedSchema)
+          .load()
+
+        query = reader.writeStream
+          .format("memory")
+          .queryName("missingSchema")
+          .start()
+
+        query.processAllAvailable()
+      }.getMessage
+      assert(errorMessage.toLowerCase(Locale.ROOT).contains(expectedMsg.toLowerCase(Locale.ROOT)))
+    } finally {
+      if (query != null) {
+        // terminating streaming query if necessary
+        query.stop()
+      }
+    }
+
+  }
+
+  test("isPartitioned doesn't contain true or false") {
+
+    var query: StreamingQuery = null
+
+    val columName = "col1"
+
+    val expectedMsg = s"$IS_PARTITIONED for column $columName must be true or false"
+
+    try {
+      val errorMessage = intercept[IllegalArgumentException] {
+
+        val metaData = (new MetadataBuilder).putString(IS_PARTITIONED, "x").build()
+
+        val partitionedSchema = new StructType().add(StructField(
+          "col1", IntegerType, true, metaData))
+
+        val reader = spark
+          .readStream
+          .format("s3-sqs")
+          .option("sqsUrl", "https://DUMMY_URL")
+          .option("fileFormat", "json")
+          .option("region", "us-east-1")
+          .schema(partitionedSchema)
+          .load()
+
+        query = reader.writeStream
+          .format("memory")
+          .queryName("missingSchema")
+          .start()
+
+        query.processAllAvailable()
+      }.getMessage
+      assert(errorMessage.toLowerCase(Locale.ROOT).contains(expectedMsg.toLowerCase(Locale.ROOT)))
+    } finally {
+      if (query != null) {
+        // terminating streaming query if necessary
+        query.stop()
+      }
+    }
+
+  }
+
+}
+


### PR DESCRIPTION
### Background

S3-SQS source doesn't support reading partition columns from the S3 bucket. As a result, the dataset formed using S3-SQS source doesn't contain the partition columns leading to issue #2 

### How this PR Handles the Problem

With the new changes, the user can specify partition columns in the schema with `isPartitioned` set to `true` in column metadata.

**Example:**

```
import org.apache.spark.sql.types._
import org.apache.spark.sql.types.MetadataBuilder

val metaData = (new MetadataBuilder).putString("isPartitioned", "true").build()

val partitionedSchema = new StructType().add(StructField("col1", IntegerType, true, metaData))
```

Also, the user needs to specify the `basePath` in options if the schema contains partition columns. Specifying partitioned
columns without specifying the `basePath` will throw an error.

**Example:**
```
 `s3://bucket/basedDir/part1=10/part2=20/file.json` will have basePath as `s3://bucket/basedDir/`
```

