### PR TITLE
Consuming sns sqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For example, to include it when starting the spark shell:
 Unlike using `--jars`, using `--packages` ensures that this library and its dependencies will be added to the classpath.
 The `--packages` argument can also be used with `bin/spark-submit`.
 
-This library is compiled for Scala 2.11 only, and intends to support Spark 2.4.0 onwards.
+This library is compiled for Scala 2.12 only, and intends to support Spark 2.4.0 onwards.
 
 ## Building S3-SQS Connector
 
@@ -49,7 +49,7 @@ sqsUrl|required, no default value|sqs queue url, like 'https://sqs.us-east-1.ama
 region|required, no default value|AWS region where queue is created
 fileFormat|required, no default value|file format for the s3 files stored on Amazon S3
 schema|required, no default value|schema of the data being read 
-sqsFetchIntervalSeconds|10|time interval (in seconds) after which to fetch messages from Amazon SQS queue
+sqsFetchIntervalMilliSeconds|10000|time interval (in milliseconds) after which to fetch messages from Amazon SQS queue
 sqsLongPollingWaitTimeSeconds|20|wait time (in seconds) for long polling on Amazon SQS queue 
 sqsMaxConnections|1|number of parallel threads to connect to Amazon SQS queue
 sqsMaxRetries|10|Maximum number of consecutive retries in case of a connection failure to SQS before giving up
@@ -71,7 +71,7 @@ An example to create a SQL stream which uses Amazon SQS to list files on S3,
                           .option("sqsUrl", queueUrl)
                           .option("region", awsRegion)
                           .option("fileFormat", "json")
-                          .option("sqsFetchIntervalSeconds", "2")
+                          .option("sqsFetchIntervalMilliSeconds", "2000")
                           .option("useInstanceProfileCredentials", "true")
                           .option("sqsLongPollingWaitTimeSeconds", "5")
                           .load()

--- a/examples/src/main/scala/org/apache/spark/examples/sql/streaming/sqs/SqsSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/streaming/sqs/SqsSourceExample.scala
@@ -51,7 +51,7 @@ object SqsSourceExample {
       .schema(schema)
       .option("sqsUrl", queueUrl)
       .option("fileFormat", fileFormat)
-      .option("sqsFetchIntervalSeconds", "2")
+      .option("sqsFetchIntervalMilliSeconds", "2000")
       .option("sqsLongPollingWaitTimeSeconds", "5")
       .option("maxFilesPerTrigger", "50")
       .option("ignoreFileDeletion", "true")

--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.qubole</groupId>
-  <artifactId>spark-sql-streaming-sqs_2.11</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <groupId>com.discovery</groupId>
+  <artifactId>spark-sql-streaming-sqs_2.12</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Spark SQL Streaming SQS</name>
   <description>Connector for faster reads from S3 using SQS</description>
-  <url>http://github.com/qubole/s3-sqs-connector</url>
+  <url>https://github.com/EurosportDigital/s3-sqs-connector</url>
 
   <developers>
     <developer>
@@ -60,9 +60,11 @@
 
   <properties>
     <sbt.project.name>spark-sql-streaming-sqs</sbt.project.name>
-    <spark.version>2.4.0</spark.version>
-    <scala.binary.version>2.11</scala.binary.version>
+    <spark.version>3.1.1</spark.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
@@ -38,7 +38,7 @@ import org.apache.spark.util.ThreadUtils
 class SqsClient(sourceOptions: SqsSourceOptions,
                 hadoopConf: Configuration) extends Logging {
 
-  private val sqsFetchIntervalSeconds = sourceOptions.fetchIntervalSeconds
+  private val sqsFetchIntervalSeconds = sourceOptions.fetchIntervalMilliSeconds
   private val sqsLongPollWaitTimeSeconds = sourceOptions.longPollWaitTimeSeconds
   private val sqsMaxRetries = sourceOptions.maxRetries
   private val maxConnections = sourceOptions.maxConnections
@@ -82,7 +82,7 @@ class SqsClient(sourceOptions: SqsSourceOptions,
     sqsFetchMessagesThread,
     0,
     sqsFetchIntervalSeconds,
-    TimeUnit.SECONDS)
+    TimeUnit.MILLISECONDS)
 
   private def sqsFetchMessages(): Seq[(String, Long, String)] = {
     val messageList = try {

--- a/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
@@ -51,12 +51,13 @@ class SqsSourceOptions(parameters: CaseInsensitiveMap[String]) extends Logging {
   val maxFileAgeMs: Long =
     Utils.timeStringAsMs(parameters.getOrElse("maxFileAge", "7d"))
 
-  val fetchIntervalSeconds: Int = parameters.get("sqsFetchIntervalSeconds").map { str =>
+  val fetchIntervalMilliSeconds: Int = parameters.get("sqsFetchIntervalMilliSeconds").map { str =>
     Try(str.toInt).toOption.filter(_ > 0).getOrElse {
       throw new IllegalArgumentException(
-        s"Invalid value '$str' for option 'sqsFetchIntervalSeconds', must be a positive integer")
+        s"Invalid value '$str' for option 'sqsFetchIntervalMilliSeconds'," +
+          s" must be a positive integer")
     }
-  }.getOrElse(10)
+  }.getOrElse(10000)
 
   val longPollWaitTimeSeconds: Int = parameters.get("sqsLongPollingWaitTimeSeconds").map { str =>
     Try(str.toInt).toOption.filter(x => x >= 0 && x <= 20).getOrElse {

--- a/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptionsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptionsSuite.scala
@@ -58,8 +58,8 @@ class SqsSourceOptionsSuite extends StreamTest {
       }
     }
 
-    testBadOptions("sqsFetchIntervalSeconds" -> "-2")("Invalid value '-2' " +
-      "for option 'sqsFetchIntervalSeconds', must be a positive integer")
+    testBadOptions("sqsFetchIntervalMilliSeconds" -> "-2")("Invalid value '-2' " +
+      "for option 'sqsFetchIntervalMilliSeconds', must be a positive integer")
     testBadOptions("sqsLongPollingWaitTimeSeconds" -> "-5")("Invalid value '-5' " +
       "for option 'sqsLongPollingWaitTimeSeconds',must be an integer between 0 and 20")
     testBadOptions("sqsMaxConnections" -> "-2")("Invalid value '-2' " +


### PR DESCRIPTION
the SNS messages if consumed from SQS differ. The information about bucket in wrapped inside a string. this needs to be pulled out and parsed to find out components like bucket key etc. This change is needed because we get a SNS create message from events team instead of SQS